### PR TITLE
add VMUPro to the list of gameid compatible devices

### DIFF
--- a/src/openmenu/src/vm2/vm2_api.c
+++ b/src/openmenu/src/vm2/vm2_api.c
@@ -141,7 +141,8 @@ check_vm2_present(maple_device_t* dev) {
 
     maple_alldevinfo_t* info = (maple_alldevinfo_t*)&recv_buff[4];
 
-    if (!strncasecmp(info->extended, "VM2 by Dreamware", 16) || !strncasecmp(info->extended, "USB RP2040 EMU  ", 16)) {
+    if (!strncasecmp(info->extended, "VM2 by Dreamware", 16) || !strncasecmp(info->extended, "USB RP2040 EMU  ", 16)
+        || !strncasecmp(info->extended, "8BITMODS VMUPro ", 16)) {
         return 1;
     }
 


### PR DESCRIPTION
- Very simple change that detects the VMUPro extended info identifier so OpenMenu sends the GameID to it